### PR TITLE
Updates to enable CI via VSTS public projects

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E24,E121,E123,E125,E126,E221,E226,E266,E704,E265
+exclude = ptvsd/_vendored/pydevd

--- a/.flake8.ci
+++ b/.flake8.ci
@@ -1,0 +1,3 @@
+[flake8]
+format = junit-xml
+output-file = .\linter-test.xml

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ help:  ## Print help about available targets.
 depends:
 	$(PYTHON) -m pip install setuptools
 	$(PYTHON) -m pip install flake8
+	$(PYTHON) -m pip install flake8_formatter_junit_xml
+	$(PYTHON) -m pip install unittest-xml-reporting
 	$(PYTHON) -m pip install coverage
 
 .PHONY: lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python Tools for Visual Studio debug server
 
-[![Build Status](https://travis-ci.org/Microsoft/ptvsd.svg?branch=master)](https://travis-ci.org/Microsoft/ptvsd)
+[![Build Status](https://ptvsd.visualstudio.com/_apis/public/build/definitions/557bd35a-f98d-4c49-9bc9-c7d548f78e4d/1/badge)](https://ptvsd.visualstudio.com/ptvsd/ptvsd%20Team/_build/index?definitionId=1)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Python Tools for Visual Studio debug server
 
 [![Build Status](https://ptvsd.visualstudio.com/_apis/public/build/definitions/557bd35a-f98d-4c49-9bc9-c7d548f78e4d/1/badge)](https://ptvsd.visualstudio.com/ptvsd/ptvsd%20Team/_build/index?definitionId=1)
+[![Build Status](https://travis-ci.org/Microsoft/ptvsd.svg?branch=master)](https://travis-ci.org/Microsoft/ptvsd)
 
 ## Contributing
 

--- a/debugger_protocol/schema/UPSTREAM
+++ b/debugger_protocol/schema/UPSTREAM
@@ -1,4 +1,4 @@
 upstream:   https://github.com/Microsoft/vscode-debugadapter-node/raw/master/debugProtocol.json
-revision:   ba5b70d4ea58fe56af226d56dd6dfeea7104eee7
-checksum:   6e26545484725c8d893a9c9a74d97b5d
-downloaded: 2018-03-21 20:14:21 (UTC)
+revision:   b97d2db700b792114b885fedc4c1ad70a9059faa
+checksum:   63f3a11ca49d4bc1bcc70b25d3918791
+downloaded: 2018-05-07 22:52:29 (UTC)

--- a/debugger_protocol/schema/debugProtocol.json
+++ b/debugger_protocol/schema/debugProtocol.json
@@ -2454,7 +2454,7 @@
 				},
 				"path": {
 					"type": "string",
-					"description": "The path of the source to be shown in the UI. It is only used to locate and load the content of the source if no sourceReference is specified (or its vaule is 0)."
+					"description": "The path of the source to be shown in the UI. It is only used to locate and load the content of the source if no sourceReference is specified (or its value is 0)."
 				},
 				"sourceReference": {
 					"type": "number",

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -28,7 +28,7 @@ def parse_cmdline(argv):
         "--full",
         help="Do full suite of tests (disables prior --quick options).",
         action="store_false",
-        target="quick"
+        dest="quick"
     )
     parser.add_argument(
         "-j",
@@ -49,25 +49,27 @@ def parse_cmdline(argv):
         action="store_true"
     )
     parser.add_argument(
-        '-n',
-        '--network',
+        "-n",
+        "--network",
         help="Perform tests taht require network connectivity.",
-        action='store_true',
-        dest='network'
+        action="store_true",
+        dest="network"
     )
     parser.add_argument(
         "--no-network",
         help="Do not perform tests that require network connectivity.",
         action="store_false",
-        dest='network'
+        dest="network"
     )
     parser.set_defaults(network=True)
     parser.add_argument(
         "-q",
         "--quick",
         help="Only do the tests under test/ptvsd.",
-        action="store_true"
+        action="store_true",
+        dest="quick"
     )
+    parser.set_defaults(quick=False)
     parser.add_argument(
         "--quick-py2",
         help=("Only do the tests under test/ptvsd, that are compatible "

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -19,15 +19,33 @@ def parse_cmdline(argv):
         description="Run tests associated to the PTVSD project."
     )
     parser.add_argument(
-        "-q",
-        "--quick",
-        help="Only do the tests under test/ptvsd.",
+        "-c",
+        "--coverage",
+        help="Generate code coverage report.",
         action="store_true"
-        )
+    )
     parser.add_argument(
-        "--quick-py2",
-        help=("Only do the tests under test/ptvsd, that are compatible "
-              "with Python 2.x."),
+        "--full",
+        help="Do full suite of tests (disables prior --quick options).",
+        action="store_false",
+        target="quick"
+    )
+    parser.add_argument(
+        "-j",
+        "--junit-xml",
+        help="Output report is generated to JUnit-style XML file specified.",
+        type=str
+    )
+    parser.add_argument(
+        "-l",
+        "--lint",
+        help="Run and report on Linter compliance.",
+        action="store_true"
+    )
+    parser.add_argument(
+        "-L",
+        "--lint-only",
+        help="Run and report on Linter compliance only, do not perform tests.",
         action="store_true"
     )
     parser.add_argument(
@@ -45,28 +63,16 @@ def parse_cmdline(argv):
     )
     parser.set_defaults(network=True)
     parser.add_argument(
-        "-c",
-        "--coverage",
-        help="Generate code coverage report.",
+        "-q",
+        "--quick",
+        help="Only do the tests under test/ptvsd.",
         action="store_true"
     )
     parser.add_argument(
-        "-l",
-        "--lint",
-        help="Run and report on Linter compliance.",
+        "--quick-py2",
+        help=("Only do the tests under test/ptvsd, that are compatible "
+              "with Python 2.x."),
         action="store_true"
-    )
-    parser.add_argument(
-        "-L",
-        "--lint-only",
-        help="Run and report on Linter compliance only, do not perform tests.",
-        action="store_true"
-    )
-    parser.add_argument(
-        "-j",
-        "--junit-xml",
-        help="Output report is generated to JUnit-style XML file specified.",
-        type=str
     )
     parser.add_argument(
         "-s",

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -144,8 +144,9 @@ def run_tests(argv, env, junit_report_file, coverage=False):
     else:
         os.environ.update(env)
         with open(junit_report_file, 'wb') as output:
-            unittest.main(testRunner=xmlrunner.XMLTestRunner(output=output), 
-                failfast=False, buffer=False, catchbreak=False, module=None, 
+            unittest.main(
+                testRunner=xmlrunner.XMLTestRunner(output=output),
+                failfast=False, buffer=False, catchbreak=False, module=None,
                 argv=argv)
 
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -97,6 +97,7 @@ def convert_argv(argv):
     config, passthru = parse_cmdline(argv)
 
     modules = set()
+    args = []
 
     for arg in passthru:
         # Unittest's main has only flags and positional args.
@@ -113,6 +114,7 @@ def convert_argv(argv):
             mod = mod.replace(os.sep, '.')
             arg = mod if not test else mod + '.' + test
             modules.add(mod)
+        args.append(arg)
 
     env = {}
     if config.network:
@@ -135,7 +137,7 @@ def convert_argv(argv):
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', start,
         ]
-    args = cmd + passthru
+    args = cmd + args
 
     return config, args, env
 

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -145,6 +145,7 @@ class CLITests(TestsBase, unittest.TestCase):
 
 class DebugTests(TestsBase, unittest.TestCase):
 
+    @unittest.skipUnless(os.environ.get('HAS_NETWORK'), 'no network')
     def test_script(self):
         argv = []
         filename = self.write_script('spam.py', """
@@ -233,6 +234,7 @@ class LifecycleTests(TestsBase, unittest.TestCase):
         out = _strip_pydevd_output(out)
         self.assertEqual(out, '')
 
+    @unittest.skipUnless(os.environ.get('HAS_NETWORK'), 'no network')
     def test_launch_ptvsd_client(self):
         argv = []
         lockfile = self.workspace.lockfile()

--- a/tests/test_tests___main__.py
+++ b/tests/test_tests___main__.py
@@ -10,161 +10,153 @@ from .__main__ import convert_argv
 class ConvertArgsTests(unittest.TestCase):
 
     def test_no_args(self):
-        runtests, lint, runtest_args = convert_argv([])
+        config, argv, env = convert_argv([])
 
-        self.assertEqual(runtest_args.argv, [
+        self.assertEqual(argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
             ])
-        self.assertEqual(runtest_args.env, {
+        self.assertEqual(env, {
             'HAS_NETWORK': '1',
         })
-        self.assertTrue(runtests)
-        self.assertFalse(lint)
-        self.assertIsNone(runtest_args.junit_xml_file)
+        self.assertFalse(config.lint_only)
+        self.assertFalse(config.lint)
 
     def test_discovery_full(self):
-        runtests, lint, runtest_args = convert_argv([
+        config, argv, env = convert_argv([
             '-v', '--failfast', '--full',
         ])
 
-        self.assertEqual(runtest_args.argv, [
+        self.assertEqual(argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
             '-v', '--failfast',
             ])
-        self.assertEqual(runtest_args.env, {
+        self.assertEqual(env, {
             'HAS_NETWORK': '1',
         })
-        self.assertTrue(runtests)
-        self.assertFalse(lint)
-        self.assertIsNone(runtest_args.junit_xml_file)
+        self.assertFalse(config.lint_only)
+        self.assertFalse(config.lint)
 
     def test_discovery_quick(self):
-        runtests, lint, runtest_args = convert_argv([
+        config, argv, env = convert_argv([
             '-v', '--failfast', '--quick',
         ])
 
-        self.assertEqual(runtest_args.argv, [
+        self.assertEqual(argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', os.path.join(TEST_ROOT, 'ptvsd'),
             '-v', '--failfast',
             ])
-        self.assertEqual(runtest_args.env, {
+        self.assertEqual(env, {
             'HAS_NETWORK': '1',
         })
-        self.assertTrue(runtests)
-        self.assertFalse(lint)
-        self.assertIsNone(runtest_args.junit_xml_file)
+        self.assertFalse(config.lint_only)
+        self.assertFalse(config.lint)
 
     def test_modules(self):
-        runtests, lint, runtest_args = convert_argv([
+        config, argv, env = convert_argv([
             '-v', '--failfast',
             'w',
             'x/y.py:Spam.test_spam'.replace('/', os.sep),
             'z:Eggs',
         ])
 
-        self.assertEqual(runtest_args.argv, [
+        self.assertEqual(argv, [
             sys.executable + ' -m unittest',
             '-v', '--failfast',
             'w',
             'x.y.Spam.test_spam',
             'z.Eggs',
             ])
-        self.assertEqual(runtest_args.env, {
+        self.assertEqual(env, {
             'HAS_NETWORK': '1',
         })
-        self.assertTrue(runtests)
-        self.assertFalse(lint)
-        self.assertIsNone(runtest_args.junit_xml_file)
+        self.assertFalse(config.lint_only)
+        self.assertFalse(config.lint)
 
     def test_no_network(self):
-        runtests, lint, runtest_args = convert_argv([
+        config, argv, env = convert_argv([
             '--no-network'
             ])
 
-        self.assertEqual(runtest_args.argv, [
+        self.assertEqual(argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
             ])
-        self.assertEqual(runtest_args.env, {})
-        self.assertTrue(runtests)
-        self.assertFalse(lint)
-        self.assertIsNone(runtest_args.junit_xml_file)
+        self.assertEqual(env, {})
+        self.assertFalse(config.lint_only)
+        self.assertFalse(config.lint)
 
     def test_lint(self):
-        runtests, lint, runtest_args = convert_argv([
+        config, argv, env = convert_argv([
             '-v',
             '--quick',
             '--lint'
             ])
 
-        self.assertEqual(runtest_args.argv, [
+        self.assertEqual(argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', os.path.join(TEST_ROOT, 'ptvsd'),
             '-v',
             ])
-        self.assertEqual(runtest_args.env, {
+        self.assertEqual(env, {
             'HAS_NETWORK': '1',
         })
-        self.assertTrue(runtests)
-        self.assertTrue(lint)
-        self.assertIsNone(runtest_args.junit_xml_file)
+
+        self.assertFalse(config.lint_only)
+        self.assertFalse(config.lint)
 
     def test_lint_only(self):
-        runtests, lint, runtest_args = convert_argv([
+        config, argv, env = convert_argv([
             '--quick', '--lint-only', '-v',
         ])
 
-        self.assertIsNone(runtest_args.argv)
-        self.assertIsNone(runtest_args.env)
-        self.assertFalse(runtests)
-        self.assertTrue(lint)
-        self.assertIsNone(runtest_args.junit_xml_file)
+        self.assertTrue(config.lint_only)
+        self.assertFalse(config.lint)
 
     def test_coverage(self):
-        runtests, lint, runtest_args = convert_argv([
+        config, argv, env = convert_argv([
             '--coverage'
             ])
 
-        self.assertEqual(runtest_args.argv, [
+        self.assertEqual(argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
             ])
-        self.assertEqual(runtest_args.env, {
+        self.assertEqual(env, {
             'HAS_NETWORK': '1',
         })
-        self.assertEqual(runtests, 'coverage')
-        self.assertFalse(lint)
-        self.assertIsNone(runtest_args.junit_xml_file, None)        
+        self.assertFalse(config.lint_only)
+        self.assertFalse(config.lint)
+        self.assertTrue(config.coverage)
 
     def test_specify_junit_file(self):
-        runtests, lint, runtest_args = convert_argv([
+        config, argv, env = convert_argv([
             '--junit-xml=./my-test-file'
         ])
 
-        self.assertEqual(runtest_args.argv, [
+        self.assertEqual(argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
         ])
-        self.assertEqual(runtest_args.env, {
+        self.assertEqual(env, {
             'HAS_NETWORK': '1',
         })
-        self.assertTrue(runtests)
-        self.assertFalse(lint)
-        self.assertEqual(runtest_args.junit_xml_file, './my-test-file')
+        self.assertFalse(config.lint_only)
+        self.assertFalse(config.lint)
+        self.assertEqual(config.junit_xml, './my-test-file')

--- a/tests/test_tests___main__.py
+++ b/tests/test_tests___main__.py
@@ -115,15 +115,19 @@ class ConvertArgsTests(unittest.TestCase):
         })
 
         self.assertFalse(config.lint_only)
-        self.assertFalse(config.lint)
+        self.assertTrue(config.lint)
+        self.assertTrue(config.quick)
+
 
     def test_lint_only(self):
-        config, argv, env = convert_argv([
+        config, _, _ = convert_argv([
             '--quick', '--lint-only', '-v',
         ])
 
         self.assertTrue(config.lint_only)
         self.assertFalse(config.lint)
+        self.assertTrue(config.quick)
+
 
     def test_coverage(self):
         config, argv, env = convert_argv([

--- a/tests/test_tests___main__.py
+++ b/tests/test_tests___main__.py
@@ -118,7 +118,6 @@ class ConvertArgsTests(unittest.TestCase):
         self.assertTrue(config.lint)
         self.assertTrue(config.quick)
 
-
     def test_lint_only(self):
         config, _, _ = convert_argv([
             '--quick', '--lint-only', '-v',
@@ -127,7 +126,6 @@ class ConvertArgsTests(unittest.TestCase):
         self.assertTrue(config.lint_only)
         self.assertFalse(config.lint)
         self.assertTrue(config.quick)
-
 
     def test_coverage(self):
         config, argv, env = convert_argv([

--- a/tests/test_tests___main__.py
+++ b/tests/test_tests___main__.py
@@ -10,7 +10,7 @@ from .__main__ import convert_argv
 class ConvertArgsTests(unittest.TestCase):
 
     def test_no_args(self):
-        argv, env, runtests, lint = convert_argv([])
+        argv, env, runtests, lint, junit_xml_file = convert_argv([])
 
         self.assertEqual(argv, [
             sys.executable + ' -m unittest',
@@ -23,9 +23,10 @@ class ConvertArgsTests(unittest.TestCase):
         })
         self.assertTrue(runtests)
         self.assertFalse(lint)
+        self.assertNotEqual(junit_xml_file, None)
 
     def test_discovery_full(self):
-        argv, env, runtests, lint = convert_argv([
+        argv, env, runtests, lint, junit_xml_file = convert_argv([
             '-v', '--failfast', '--full',
         ])
 
@@ -41,9 +42,10 @@ class ConvertArgsTests(unittest.TestCase):
         })
         self.assertTrue(runtests)
         self.assertFalse(lint)
+        self.assertNotEqual(junit_xml_file, None)
 
     def test_discovery_quick(self):
-        argv, env, runtests, lint = convert_argv([
+        argv, env, runtests, lint, junit_xml_file = convert_argv([
             '-v', '--failfast', '--quick',
         ])
 
@@ -59,9 +61,10 @@ class ConvertArgsTests(unittest.TestCase):
         })
         self.assertTrue(runtests)
         self.assertFalse(lint)
+        self.assertNotEqual(junit_xml_file, None)
 
     def test_modules(self):
-        argv, env, runtests, lint = convert_argv([
+        argv, env, runtests, lint, junit_xml_file = convert_argv([
             '-v', '--failfast',
             'w',
             'x/y.py:Spam.test_spam'.replace('/', os.sep),
@@ -80,9 +83,12 @@ class ConvertArgsTests(unittest.TestCase):
         })
         self.assertTrue(runtests)
         self.assertFalse(lint)
+        self.assertNotEqual(junit_xml_file, None)
 
     def test_no_network(self):
-        argv, env, runtests, lint = convert_argv(['--no-network'])
+        argv, env, runtests, lint, junit_xml_file = convert_argv([
+            '--no-network'
+            ])
 
         self.assertEqual(argv, [
             sys.executable + ' -m unittest',
@@ -93,9 +99,14 @@ class ConvertArgsTests(unittest.TestCase):
         self.assertEqual(env, {})
         self.assertTrue(runtests)
         self.assertFalse(lint)
+        self.assertNotEqual(junit_xml_file, None)
 
     def test_lint(self):
-        argv, env, runtests, lint = convert_argv(['-v', '--quick', '--lint'])
+        argv, env, runtests, lint, junit_xml_file = convert_argv([
+            '-v',
+            '--quick',
+            '--lint'
+            ])
 
         self.assertEqual(argv, [
             sys.executable + ' -m unittest',
@@ -109,9 +120,10 @@ class ConvertArgsTests(unittest.TestCase):
         })
         self.assertTrue(runtests)
         self.assertTrue(lint)
+        self.assertNotEqual(junit_xml_file, None)
 
     def test_lint_only(self):
-        argv, env, runtests, lint = convert_argv([
+        argv, env, runtests, lint, junit_xml_file = convert_argv([
             '--quick', '--lint-only', '-v',
         ])
 
@@ -119,9 +131,12 @@ class ConvertArgsTests(unittest.TestCase):
         self.assertIsNone(env)
         self.assertFalse(runtests)
         self.assertTrue(lint)
+        self.assertNotEqual(junit_xml_file, None)
 
     def test_coverage(self):
-        argv, env, runtests, lint = convert_argv(['--coverage'])
+        argv, env, runtests, lint, junit_xml_file = convert_argv([
+            '--coverage'
+            ])
 
         self.assertEqual(argv, [
             sys.executable + ' -m unittest',
@@ -134,3 +149,22 @@ class ConvertArgsTests(unittest.TestCase):
         })
         self.assertEqual(runtests, 'coverage')
         self.assertFalse(lint)
+        self.assertNotEqual(junit_xml_file, None)
+
+    def test_specify_junit_file(self):
+        argv, env, runtests, lint, junit_xml_file = convert_argv([
+            '--junit-xml=./my-test-file'
+            ])
+
+        self.assertEqual(argv, [
+            sys.executable + ' -m unittest',
+            'discover',
+            '--top-level-directory', PROJECT_ROOT,
+            '--start-directory', PROJECT_ROOT,
+            ])
+        self.assertEqual(env, {
+            'HAS_NETWORK': '1',
+        })
+        self.assertTrue(runtests)
+        self.assertFalse(lint)
+        self.assertEqual(junit_xml_file, './my-test-file')

--- a/tests/test_tests___main__.py
+++ b/tests/test_tests___main__.py
@@ -10,161 +10,161 @@ from .__main__ import convert_argv
 class ConvertArgsTests(unittest.TestCase):
 
     def test_no_args(self):
-        argv, env, runtests, lint, junit_xml_file = convert_argv([])
+        runtests, lint, runtest_args = convert_argv([])
 
-        self.assertEqual(argv, [
+        self.assertEqual(runtest_args.argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
             ])
-        self.assertEqual(env, {
+        self.assertEqual(runtest_args.env, {
             'HAS_NETWORK': '1',
         })
         self.assertTrue(runtests)
         self.assertFalse(lint)
-        self.assertNotEqual(junit_xml_file, None)
+        self.assertIsNone(runtest_args.junit_xml_file)
 
     def test_discovery_full(self):
-        argv, env, runtests, lint, junit_xml_file = convert_argv([
+        runtests, lint, runtest_args = convert_argv([
             '-v', '--failfast', '--full',
         ])
 
-        self.assertEqual(argv, [
+        self.assertEqual(runtest_args.argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
             '-v', '--failfast',
             ])
-        self.assertEqual(env, {
+        self.assertEqual(runtest_args.env, {
             'HAS_NETWORK': '1',
         })
         self.assertTrue(runtests)
         self.assertFalse(lint)
-        self.assertNotEqual(junit_xml_file, None)
+        self.assertIsNone(runtest_args.junit_xml_file)
 
     def test_discovery_quick(self):
-        argv, env, runtests, lint, junit_xml_file = convert_argv([
+        runtests, lint, runtest_args = convert_argv([
             '-v', '--failfast', '--quick',
         ])
 
-        self.assertEqual(argv, [
+        self.assertEqual(runtest_args.argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', os.path.join(TEST_ROOT, 'ptvsd'),
             '-v', '--failfast',
             ])
-        self.assertEqual(env, {
+        self.assertEqual(runtest_args.env, {
             'HAS_NETWORK': '1',
         })
         self.assertTrue(runtests)
         self.assertFalse(lint)
-        self.assertNotEqual(junit_xml_file, None)
+        self.assertIsNone(runtest_args.junit_xml_file)
 
     def test_modules(self):
-        argv, env, runtests, lint, junit_xml_file = convert_argv([
+        runtests, lint, runtest_args = convert_argv([
             '-v', '--failfast',
             'w',
             'x/y.py:Spam.test_spam'.replace('/', os.sep),
             'z:Eggs',
         ])
 
-        self.assertEqual(argv, [
+        self.assertEqual(runtest_args.argv, [
             sys.executable + ' -m unittest',
             '-v', '--failfast',
             'w',
             'x.y.Spam.test_spam',
             'z.Eggs',
             ])
-        self.assertEqual(env, {
+        self.assertEqual(runtest_args.env, {
             'HAS_NETWORK': '1',
         })
         self.assertTrue(runtests)
         self.assertFalse(lint)
-        self.assertNotEqual(junit_xml_file, None)
+        self.assertIsNone(runtest_args.junit_xml_file)
 
     def test_no_network(self):
-        argv, env, runtests, lint, junit_xml_file = convert_argv([
+        runtests, lint, runtest_args = convert_argv([
             '--no-network'
             ])
 
-        self.assertEqual(argv, [
+        self.assertEqual(runtest_args.argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
             ])
-        self.assertEqual(env, {})
+        self.assertEqual(runtest_args.env, {})
         self.assertTrue(runtests)
         self.assertFalse(lint)
-        self.assertNotEqual(junit_xml_file, None)
+        self.assertIsNone(runtest_args.junit_xml_file)
 
     def test_lint(self):
-        argv, env, runtests, lint, junit_xml_file = convert_argv([
+        runtests, lint, runtest_args = convert_argv([
             '-v',
             '--quick',
             '--lint'
             ])
 
-        self.assertEqual(argv, [
+        self.assertEqual(runtest_args.argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', os.path.join(TEST_ROOT, 'ptvsd'),
             '-v',
             ])
-        self.assertEqual(env, {
+        self.assertEqual(runtest_args.env, {
             'HAS_NETWORK': '1',
         })
         self.assertTrue(runtests)
         self.assertTrue(lint)
-        self.assertNotEqual(junit_xml_file, None)
+        self.assertIsNone(runtest_args.junit_xml_file)
 
     def test_lint_only(self):
-        argv, env, runtests, lint, junit_xml_file = convert_argv([
+        runtests, lint, runtest_args = convert_argv([
             '--quick', '--lint-only', '-v',
         ])
 
-        self.assertIsNone(argv)
-        self.assertIsNone(env)
+        self.assertIsNone(runtest_args.argv)
+        self.assertIsNone(runtest_args.env)
         self.assertFalse(runtests)
         self.assertTrue(lint)
-        self.assertNotEqual(junit_xml_file, None)
+        self.assertIsNone(runtest_args.junit_xml_file)
 
     def test_coverage(self):
-        argv, env, runtests, lint, junit_xml_file = convert_argv([
+        runtests, lint, runtest_args = convert_argv([
             '--coverage'
             ])
 
-        self.assertEqual(argv, [
+        self.assertEqual(runtest_args.argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
             ])
-        self.assertEqual(env, {
+        self.assertEqual(runtest_args.env, {
             'HAS_NETWORK': '1',
         })
         self.assertEqual(runtests, 'coverage')
         self.assertFalse(lint)
-        self.assertNotEqual(junit_xml_file, None)
+        self.assertIsNone(runtest_args.junit_xml_file, None)        
 
     def test_specify_junit_file(self):
-        argv, env, runtests, lint, junit_xml_file = convert_argv([
+        runtests, lint, runtest_args = convert_argv([
             '--junit-xml=./my-test-file'
-            ])
+        ])
 
-        self.assertEqual(argv, [
+        self.assertEqual(runtest_args.argv, [
             sys.executable + ' -m unittest',
             'discover',
             '--top-level-directory', PROJECT_ROOT,
             '--start-directory', PROJECT_ROOT,
-            ])
-        self.assertEqual(env, {
+        ])
+        self.assertEqual(runtest_args.env, {
             'HAS_NETWORK': '1',
         })
         self.assertTrue(runtests)
         self.assertFalse(lint)
-        self.assertEqual(junit_xml_file, './my-test-file')
+        self.assertEqual(runtest_args.junit_xml_file, './my-test-file')


### PR DESCRIPTION
Small tweaks that enable VSTS builds against this repo.

- Update `tests` module to support the output of VSTS-compatible file formats for JUnit and Cobertura
- Create `flake8` specific config file - one for local use and one for ci
- Switch the build badge in the readme.md file to the VSTS badge

**NOTE**: Don't merge this to the Microsoft/ptvsd repo until we are ready to make the full switch to VSTS.